### PR TITLE
Added the support of bananaPi R3 device profile

### DIFF
--- a/profiles/bananapi_bpi-r3.yml
+++ b/profiles/bananapi_bpi-r3.yml
@@ -1,0 +1,27 @@
+---
+profile: bananapi_bpi-r3
+target: mediatek
+subtarget: filogic
+description: Build image for the Banana Pi BPi-R3
+image: bin/targets/mediatek/mt7986/openwrt-mediatek-mt7986-bananapi_bpi-r3-squashfs-sysupgrade.tar
+feeds:
+  - name: ucentral
+    path: ../../feeds/ucentral
+
+include:
+  - ucentral-ap
+
+packages:
+  - ucode
+  - ucode-mod-math
+  - ucode-mod-resolv
+  - ucode-mod-rtnl
+  - ucode-mod-struct
+  - ucode-mod-uci
+  - wpad-openssl
+  - wireless-regdb
+  - iptables-mod-physdev
+
+diffconfig: |
+  CONFIG_NET_IP_TUNNEL=y
+  CONFIG_BUSYBOX_CUSTOM=y


### PR DESCRIPTION
**Fixes** #3 - Added the support of Banana Pi R3 device profiles.

**Summary:**
This pull request adds the support for the Banana Pi R3 device profiles.

**Changes:**
- Added the device profile for Banana Pi R3 at `/profiles/` directory as `bananapi_bpi-r3.yml`.
